### PR TITLE
fix: 解决默认推理模式下,llama3的stop word不生效的问题

### DIFF
--- a/api/generation/stream.py
+++ b/api/generation/stream.py
@@ -46,6 +46,14 @@ def generate_stream(
     stop_token_ids = params.get("stop_token_ids") or []
     if tokenizer.eos_token_id not in stop_token_ids:
         stop_token_ids.append(tokenizer.eos_token_id)
+    if stop_str:
+        if isinstance(stop_str, str):
+            stop_str = [stop_str]
+        elif not isinstance(stop_str, Iterable):
+            raise ValueError("Invalid stop field type.")
+        stop_token_ids.extend(tokenizer.convert_tokens_to_ids(stop_str))
+        # Remove duplicated stop tokens
+        stop_token_ids = list(set(stop_token_ids))
 
     logits_processor = prepare_logits_processor(
         temperature, repetition_penalty, top_p, top_k


### PR DESCRIPTION
  之前是将PromptTemplate的stop作为字符串,使用字符串匹配来判断是否stop,现在改为转换为token id后再匹配